### PR TITLE
Polishing

### DIFF
--- a/docs/book/23-Annotations.md
+++ b/docs/book/23-Annotations.md
@@ -107,7 +107,7 @@ public class PasswordUtils {
 }
 ```
 
-注解的元素在使用时表现为 名-值 对的形式，并且需要放置在 `@UseCase` 声明之后的括号内。在 `encryptPassword()` 方法的注解中，并没有给出 **description** 的默认值，所以在 **@interface UseCase** 的注解处理器分析处理这个类的时候会使用该元素的默认值。
+注解的元素在使用时表现为 名-值 对的形式，并且需要放置在 `@UseCase` 声明之后的括号内。在 `encryptPassword()` 方法的注解中，并没有给出 **description** 的值，所以在 **@interface UseCase** 的注解处理器分析处理这个类的时候会使用该元素的默认值。
 
 你应该能够想象到如何使用这套工具来“勾勒”出将要建造的系统，然后在建造的过程中逐渐实现系统的各项功能。
 


### PR DESCRIPTION
原文:
`The annotation for encryptPassword() is not passed a value for description element here,`
翻译:
`并没有给出 **description** 的默认值,`
建议:
去掉`默认`较为合适