### PR TITLE
Update 12-Collections.md

### DIFF
--- a/docs/book/12-Collections.md
+++ b/docs/book/12-Collections.md
@@ -194,7 +194,7 @@ public class SimpleCollection {
 
 在 **java.util** 包中的 **Arrays** 和 **Collections** 类中都有很多实用的方法，可以在一个 **Collection** 中添加一组元素。
 
-`Arrays.asList()` 方法接受一个数组或是逗号分隔的元素列表（使用可变参数），并将其转换为 **List** 对象。 `Collections.addAll()` 方法接受一个 **Collection** 对象，以及一个数组或是一个逗号分隔的列表，将其中元素添加到 **Collection** 中。下边的示例展示了这两个方法，以及更通用的 `addAll()` 方法，所有 **Collection** 类型都包含该方法：
+`Arrays.asList()` 方法接受一个数组或是逗号分隔的元素列表（使用可变参数），并将其转换为 **List** 对象。 `Collections.addAll()` 方法接受一个 **Collection** 对象，以及一个数组或是一个逗号分隔的列表，将其中元素添加到 **Collection** 中。下边的示例展示了这两个方法，以及更通用的 、所有 **Collection** 类型都包含的`addAll()` 方法：
 
 ```java
 // collections/AddingGroups.java


### PR DESCRIPTION
优化翻译：
英文原文：“Here you see both methods, as well as the more conventional addAll() method that’s part of all Collection types:”
原翻译：下边的示例展示了这两个方法，以及更通用的 addAll() 方法，所有 Collection 类型都包含该方法：
应改为：下边的示例展示了这两个方法，以及更通用的 、所有 Collection类型都包含的addAll()`方法：
原翻译中说的“addAll() 方法”，容易误解为上文所说的Collections.addAll()方法，作者此处指的是Collection类型的addAll()方法，改后的翻译意思更明确，更易理解。