### PR TITLE
第12章翻译优化

### DIFF
--- a/docs/book/12-Collections.md
+++ b/docs/book/12-Collections.md
@@ -334,7 +334,7 @@ public class PrintingCollections {
 
 ## 列表List
 
-**List**s承诺将元素保存在特定的序列中。 **List** 接口在 **Collection** 的基础上添加了许多方法，允许在 **List** 的中间插入和删除元素。
+**List**承诺将元素保存在特定的序列中。 **List** 接口在 **Collection** 的基础上添加了许多方法，允许在 **List** 的中间插入和删除元素。
 
 有两种类型的 **List** ：
 
@@ -610,7 +610,7 @@ public class CrossCollectionIteration2 {
 <!-- ListIterator -->
 ### ListIterator
 
-**ListIterator** 是一个更强大的 **Iterator** 子类型，它只能由各种 **List** 类生成。 **Iterator** 只能向前移动，而 **ListIterator** 可以双向移动。它还可以生成相对于迭代器在列表中指向的当前位置的后一个和前一个元素的索引，并且可以使用 `set()` 方法替换它访问过的最近一个元素。可以通过调用 `listIterator()` 方法来生成指向 **List** 开头处的 **ListIterator** ，还可以通过调用 `listIterator(n)` 创建一个一开始就指向列表索引号为 **n** 的元素处的 **ListIterator** 。 下面的示例演示了所有这些能力：
+**ListIterator** 是一个更强大的 **Iterator** 子类型，它只能由各种 **List** 类生成。 **Iterator** 只能向前移动，而 **ListIterator** 可以双向移动。它可以生成迭代器在列表中指向位置的后一个和前一个元素的索引，并且可以使用 `set()` 方法替换它访问过的最近一个元素。可以通过调用 `listIterator()` 方法来生成指向 **List** 开头处的 **ListIterator** ，还可以通过调用 `listIterator(n)` 创建一个一开始就指向列表索引号为 **n** 的元素处的 **ListIterator** 。 下面的示例演示了所有这些能力：
 
 ```java
 // collections/ListIteration.java


### PR DESCRIPTION
第337行，将原翻译“Lists承诺将元素保存在特定的序列中。”中的Lists改为List，因为在中文语法中，没有复数。
第613行，英文原文：“It can produce indices of the next and previous elements relative to where the iterator is pointing in the list,”原翻译太拗口，改为：“它可以生成迭代器在列表中指向位置的后一个和前一个元素的索引，”