### PR TITLE
With AtomicInteger, synchronized is no longer needed.

### DIFF
--- a/docs/book/Appendix-Low-Level-Concurrency.md
+++ b/docs/book/Appendix-Low-Level-Concurrency.md
@@ -1053,7 +1053,7 @@ public class
 AtomicSerialNumbers extends SerialNumbers {
   private AtomicInteger serialNumber =
     new AtomicInteger();
-  public synchronized int nextSerialNumber() {
+  public int nextSerialNumber() {
     return serialNumber.getAndIncrement();
   }
   public static void main(String[] args) {


### PR DESCRIPTION
This chapter is to use AtomicInteger to replace synchronized function. So no more synchronized for nextSerialNumber()