### PR TITLE
Update 24-Concurrent-Programming.md

### DIFF
--- a/docs/book/24-Concurrent-Programming.md
+++ b/docs/book/24-Concurrent-Programming.md
@@ -1439,7 +1439,7 @@ public class CompletedMachina {
 
 **completedFuture()** 创建一个“已经完成”的 **CompletableFuture** 。对这样一个未来做的唯一有用的事情是 **get()** 里面的对象，所以这看起来似乎没有用。注意 **CompletableFuture** 被输入到它包含的对象。这个很重要。
 
-通常，**get()** 在等待结果时阻塞调用线程。此块可以通过 **InterruptedException** 或 **ExecutionException** 中断。在这种情况下，阻止永远不会发生，因为 CompletableFutureis 已经完成，所以答案立即可用。
+通常，**get()** 在等待结果时阻塞调用线程。此块可以通过 **InterruptedException** 或 **ExecutionException** 中断。在这种情况下，阻止永远不会发生，因为 **CompletableFuture** 已经完成，所以结果立即可用。
 
 当我们将 **handle()** 包装在 **CompletableFuture** 中时，发现我们可以在 **CompletableFuture** 上添加操作来处理所包含的对象，使得事情变得更加有趣：
 


### PR DESCRIPTION
> ”the blocking never happens because the CompletableFuture is already complete, so the answer is instantly available.“ 

1. 笔误
2. answer这里应该是指结果